### PR TITLE
Use new auth library and move to organization

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1085,7 +1085,7 @@ module.exports = {
     'no-use-before-define': 'error',
   },
   'parserOptions': {
-    'ecmaVersion': 2017,
+    'ecmaVersion': 2018,
     'sourceType': 'module',
   }
 };

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ You can get your credentials through the [developer portal](https://developer.sa
 This prints a list of the holidays of 2017 and whether they are [national holidays](#holiday-entry).
 You will need to get a JWT secret or Bearer token with access to the Stores API from the [developer portal](https://developer.sallinggroup.com/). 
 ```js
-const { SallingGroupAPI } = require('sg-base-sdk');
-const HolidaysSDK = require('./index');
-const instance = new HolidaysSDK(SallingGroupAPI.bearer('my_token'));
+const Holidays = require('@salling-group/holidays');
+const instance = new Holidays({
+  'applicationName': 'My Application v1.0.0',
+  'auth': {
+    'type': 'bearer',
+    'token': 'my_token',
+  },
+});
 
 instance.holidaysInBetween('2017-01-01', '2017-12-31').then((holidays) => {
   for (const holiday of holidays) {
@@ -68,15 +73,31 @@ An example of this could be:
 ```
 
 ## Documentation
-### `constructor(api)`
+### `constructor(options)`
 This initializes a new Holidays SDK object.
-`api` must be an instance returned by `sg-base-sdk`.
+`options` must be an object containing an `auth` object with the following contract:
+
+|Property|Value|Required|Description|
+|--------|-----|--------|-----------|
+|`type`|`'jwt'` or `'bearer'`|Yes|The authentication type. This is either a JWT or a Bearer Token.|
+|`token`|`String`|If `type` is `'bearer'`.|The token associared with the bearer token credentials.|
+|`email`|`String`|If `type` is `'jwt'`.|The email associated with the JWT credentials.|
+|`secret`|`String`|If `type` is `'jwt'`.|The secret associated with the JWT credentials.|
+
+`applicationName` should be set in the `options` object, but this is optional.
+(This value will be sent in the UserAgent during requests.)
 
 Example:
 ```js
-const { SallingGroupAPI } = require('sg-base-sdk');
-const HolidaysSDK = require('sg-holidays-sdk');
-const instance = new HolidaysSDK(SallingGroupAPI.jwt('my_email', 'my_key'));
+const Holidays = require('@salling-group/holidays');
+const instance = new Holidays({
+  'applicationName': 'My Application v1.0.0',
+  'auth': {
+    'type': 'jwt',
+    'email': 'my_email',
+    'secret': 'my_secret'
+  },
+});
 ```
 
 ### `async isHoliday(date)`

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 const BASE_URL = '/v1/holidays/';
+const { createInstance } = require('@salling-group/auth');
+const { version } = require('./package');
 
 /**
  * @typedef {Object} Holiday A holiday entry.
@@ -36,10 +38,21 @@ class HolidaysAPI {
   /**
    * Initialize a new Holidays API wrapper.
    *
-   * @param {Object} api A SallingGroupAPI instance.
+   * @param {Object} options Options for the instance.
+   * @param {Object} options.auth Credentials for the instance.
+   * @param {String} options.auth.type The type of authentication.
+   * @param {String} [options.auth.email] The email used for JWT.
+   * @param {String} [options.auth.secret] The secret used for JWT.
+   * @param {String} [options.auth.token] The token used for Bearer.
+   * @param {String} [options.applicationName]
+   * The name of the application which will use this instance.
+   * This will be sent in the user-agent header.
    */
-  constructor(api) {
-    this.api = api;
+  constructor(options) {
+    this.instance = createInstance({
+      ...options,
+      'baseName': `Holidays SDK v${version}`,
+    });
   }
 
   /**
@@ -49,7 +62,7 @@ class HolidaysAPI {
    * @returns {Promise<Boolean>} Whether the date is a holiday.
    */
   async isHoliday(date) {
-    const response = await this.api.get(`${BASE_URL}is-holiday`, { 'params': { 'date': toDateFormat(date) } });
+    const response = await this.instance.get(`${BASE_URL}is-holiday`, { 'params': { 'date': toDateFormat(date) } });
     return response.data;
   }
 
@@ -60,7 +73,7 @@ class HolidaysAPI {
    * @returns {Promise<[Holiday]>} Holidays between the two dates.
    */
   async holidaysInBetween(startDate, endDate) {
-    const response = await this.api.get(BASE_URL, {
+    const response = await this.instance.get(BASE_URL, {
       'params': {
         'endDate': toDateFormat(endDate),
         'startDate': toDateFormat(startDate),
@@ -76,7 +89,7 @@ class HolidaysAPI {
    * @returns {Promise<[Holiday]>} Holidays between today and the given end date.
    */
   async holidaysUntil(date) {
-    const response = await this.api.get(BASE_URL, {
+    const response = await this.instance.get(BASE_URL, {
       'params': {
         'endDate': toDateFormat(date),
       },
@@ -90,7 +103,7 @@ class HolidaysAPI {
    * @returns {Promise<[Holiday]>} Holidays in the upcoming year from today.
    */
   async holidaysWithinUpcomingYear() {
-    const response = await this.api.get(BASE_URL);
+    const response = await this.instance.get(BASE_URL);
     return response.data;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,17 @@
 {
-  "name": "sg-holidays-sdk",
+  "name": "@salling-group/holidays",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@salling-group/auth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@salling-group/auth/-/auth-1.0.0.tgz",
+      "integrity": "sha512-drc4KsYQ62r/Y37QfvZGOELUee7uM7lvbiprt/Z6bsF00q5OZRaIuA580n5VcFspRsQTC96+BDmcTHktIWXF5A==",
+      "requires": {
+        "axios": "0.18.0"
+      }
+    },
     "acorn": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
@@ -1034,14 +1042,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
-    },
-    "sg-base-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sg-base-sdk/-/sg-base-sdk-1.0.0.tgz",
-      "integrity": "sha512-08fv4XGXpQXNMiB/5/ePkTnqWXgwaO3Et4nihy131V8arsZyhkw2tWE0dP8ltjkMEPKper5f05cqGJgFWPkl1Q==",
-      "requires": {
-        "axios": "0.18.0"
-      }
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sg-holidays-sdk",
+  "name": "@salling-group/holidays",
   "version": "1.0.0",
   "description": "An SDK for Salling Group's Holidays API ",
   "main": "index.js",
@@ -9,7 +9,7 @@
     "url": "https://developer.sallinggroup.com/"
   },
   "dependencies": {
-    "sg-base-sdk": "1.0.0"
+    "@salling-group/auth": "1.0.0"
   },
   "devDependencies": {
     "eslint": "5.2.0"


### PR DESCRIPTION
This module now uses the new @salling-group/auth library that replaces the
auth part of the base-sdk (which is currently being deprecated).

Furthermore, the package will now be in the organization @salling-group
under the name `holidays`.